### PR TITLE
feat: Portfolio page (Apps/Libraries/Tools)

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -6,8 +6,8 @@
   weight = 10
 
 [[main]]
-  name = "Projects"
-  pageRef = "projects"
+  name = "Portfolio"
+  pageRef = "portfolio"
   weight = 15
 
 [[main]]

--- a/content/portfolio/_index.md
+++ b/content/portfolio/_index.md
@@ -1,9 +1,10 @@
 ---
-title: "Projects & Tools"
-description: "Apps and free tools built by Andryo Marzuki — colour, PDF, image, QR, OCR and more. Private, in-browser, no signup."
+title: "Portfolio"
+description: "Apps, libraries and free tools built by Andryo Marzuki — colour, charts, PDF, image, QR, OCR and more."
+aliases: ["/projects/"]
 ---
 
-Everything I've built — a couple of apps, and a growing set of free, **private, in-browser** tools. No uploads, no signups, no paywalls — they run entirely on your own device.
+Everything I've built — an app, a library, and a growing set of free, **private, in-browser** tools. No uploads, no signups, no paywalls.
 
 ## Apps
 
@@ -11,9 +12,11 @@ Everything I've built — a couple of apps, and a growing set of free, **private
 
 A colour gradient & palette toolkit. Stepped LAB gradients, harmonious palettes you can seed and lock, WCAG contrast + colour-blindness checks, and export to CSS / Tailwind / SCSS / JSON / SVG.
 
-### [charted](https://charted.mrzk.io)
+## Libraries
 
-Zero-dependency SVG charting for Python. 15 chart types, no numpy, no pandas, no matplotlib — pure stdlib.
+### charted &nbsp;·&nbsp; [site](https://charted.mrzk.io) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/charted/) &nbsp;·&nbsp; [GitHub](https://github.com/marzukia/charted)
+
+Zero-dependency SVG charting for Python — `pip install charted`. 15 chart types, no numpy, no pandas, no matplotlib. Pure standard library, works anywhere Python runs, and ships an MCP server.
 
 ## Tools
 


### PR DESCRIPTION
Restructure showcase into a Portfolio page separating Apps (colours) / Libraries (charted) / Tools (the 8). /projects aliases→/portfolio. Nav: Projects→Portfolio. Validated on Hugo 0.163.3.