### PR TITLE
feat: portfolio card grid (no TOC/list)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -53,3 +53,96 @@ code::after {
     content: "" !important;
 }
 
+/* ── Portfolio cards ─────────────────────────────────────────── */
+.pf-h {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 2.6rem 0 0.9rem;
+    color: rgb(var(--color-neutral-800));
+}
+.pf-note {
+    color: rgb(var(--color-neutral-500));
+    font-size: 0.95rem;
+    margin: -0.4rem 0 0.9rem;
+}
+.pf-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+    gap: 1rem;
+    margin: 0 0 1.5rem;
+}
+.pf-card {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    padding: 1.3rem 1.4rem 1.25rem;
+    border: 1px solid rgb(var(--color-neutral-200));
+    border-radius: 14px;
+    background: rgb(var(--color-neutral));
+    text-decoration: none !important;
+    color: inherit;
+    transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease;
+}
+.pf-card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, #2f9d8d 0 33.3%, #e8b04b 33.3% 66.6%, #d9594c 66.6%);
+}
+.pf-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+    border-color: rgb(var(--color-neutral-300));
+}
+.pf-card h3 {
+    margin: 0.45rem 0 0.4rem;
+    font-size: 1.08rem;
+    font-weight: 700;
+    color: rgb(var(--color-neutral-900));
+}
+.pf-card p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: rgb(var(--color-neutral-600));
+}
+.pf-card p em {
+    font-style: normal;
+    color: rgb(var(--color-neutral-500));
+}
+.pf-card code {
+    background: rgb(var(--color-neutral-100));
+    padding: 0.05rem 0.32rem;
+    border-radius: 4px;
+}
+.pf-go {
+    margin-top: 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #2f9d8d;
+    font-family: monospace;
+}
+.pf-links {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+}
+.pf-links a {
+    color: #2f9d8d;
+    font-weight: 600;
+}
+.dark .pf-card {
+    background: rgb(var(--color-neutral-800));
+    border-color: rgb(var(--color-neutral-700));
+}
+.dark .pf-card:hover {
+    border-color: rgb(var(--color-neutral-600));
+}
+.dark .pf-go,
+.dark .pf-links a {
+    color: #41b6a6;
+}
+

--- a/content/portfolio/_index.md
+++ b/content/portfolio/_index.md
@@ -2,35 +2,39 @@
 title: "Portfolio"
 description: "Apps, libraries and free tools built by Andryo Marzuki — colour, charts, PDF, image, QR, OCR and more."
 aliases: ["/projects/"]
+layout: "simple"
+showTableOfContents: false
 ---
 
 Everything I've built — an app, a library, and a growing set of free, **private, in-browser** tools. No uploads, no signups, no paywalls.
 
-## Apps
+<h2 class="pf-h">Apps</h2>
+<div class="pf-grid">
+  <a class="pf-card" href="https://colours.mrzk.io">
+    <h3>colours</h3>
+    <p>A colour gradient &amp; palette toolkit — stepped LAB gradients, seedable harmonious palettes, WCAG contrast + colour-blindness checks, and export to CSS / Tailwind / SCSS / JSON / SVG.</p>
+    <span class="pf-go">colours.mrzk.io →</span>
+  </a>
+</div>
 
-### [colours](https://colours.mrzk.io)
+<h2 class="pf-h">Libraries</h2>
+<div class="pf-grid">
+  <div class="pf-card">
+    <h3>charted</h3>
+    <p>Zero-dependency SVG charting for Python — <code>pip install charted</code>. 15 chart types, no numpy/pandas/matplotlib. Pure stdlib, runs anywhere, ships an MCP server.</p>
+    <span class="pf-links"><a href="https://charted.mrzk.io">site</a> · <a href="https://pypi.org/project/charted/">PyPI</a> · <a href="https://github.com/marzukia/charted">GitHub</a></span>
+  </div>
+</div>
 
-A colour gradient & palette toolkit. Stepped LAB gradients, harmonious palettes you can seed and lock, WCAG contrast + colour-blindness checks, and export to CSS / Tailwind / SCSS / JSON / SVG.
-
-## Libraries
-
-### charted &nbsp;·&nbsp; [site](https://charted.mrzk.io) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/charted/) &nbsp;·&nbsp; [GitHub](https://github.com/marzukia/charted)
-
-Zero-dependency SVG charting for Python — `pip install charted`. 15 chart types, no numpy, no pandas, no matplotlib. Pure standard library, works anywhere Python runs, and ships an MCP server.
-
-## Tools
-
-Free, and everything happens in your browser — nothing is ever uploaded.
-
-- **[PDF Toolkit](https://pdf.mrzk.io)** — merge, split, compress & convert PDFs *(an iLovePDF / Smallpdf alternative)*
-- **[Image Converter](https://convert.mrzk.io)** — HEIC→JPG, WebP, PNG, compress & resize *(a TinyPNG alternative)*
-- **[QR Code Generator](https://qr.mrzk.io)** — QR codes with logo, colours & styles
-- **[Image to Text (OCR)](https://ocr.mrzk.io)** — extract text from any image
-- **[OG Image Generator](https://og.mrzk.io)** — social share images (1200×630)
-- **[Subtitle Editor](https://subs.mrzk.io)** — edit, time-shift & convert .srt / .vtt
-- **[EXIF Viewer & Stripper](https://exif.mrzk.io)** — view and remove photo metadata
-- **[Favicon Generator](https://favicon.mrzk.io)** — turn any image into a full favicon set
-
----
-
-All built by **Andryo Marzuki** · [github.com/marzukia](https://github.com/marzukia) · [LinkedIn](https://www.linkedin.com/in/andryomarzuki/)
+<h2 class="pf-h">Tools</h2>
+<p class="pf-note">Free, and everything happens in your browser — nothing is ever uploaded.</p>
+<div class="pf-grid">
+  <a class="pf-card" href="https://pdf.mrzk.io"><h3>PDF Toolkit</h3><p>Merge, split, compress &amp; convert PDFs <em>(an iLovePDF / Smallpdf alternative)</em>.</p><span class="pf-go">pdf.mrzk.io →</span></a>
+  <a class="pf-card" href="https://convert.mrzk.io"><h3>Image Converter</h3><p>HEIC→JPG, WebP, PNG — compress &amp; resize <em>(a TinyPNG alternative)</em>.</p><span class="pf-go">convert.mrzk.io →</span></a>
+  <a class="pf-card" href="https://qr.mrzk.io"><h3>QR Code Generator</h3><p>QR codes with logo, colours &amp; dot styles. PNG / SVG export.</p><span class="pf-go">qr.mrzk.io →</span></a>
+  <a class="pf-card" href="https://ocr.mrzk.io"><h3>Image to Text (OCR)</h3><p>Extract text from any image, right in your browser.</p><span class="pf-go">ocr.mrzk.io →</span></a>
+  <a class="pf-card" href="https://og.mrzk.io"><h3>OG Image Generator</h3><p>Make social share images (1200×630) in seconds.</p><span class="pf-go">og.mrzk.io →</span></a>
+  <a class="pf-card" href="https://subs.mrzk.io"><h3>Subtitle Editor</h3><p>Edit, time-shift &amp; convert .srt / .vtt subtitles.</p><span class="pf-go">subs.mrzk.io →</span></a>
+  <a class="pf-card" href="https://exif.mrzk.io"><h3>EXIF Viewer &amp; Stripper</h3><p>View and remove photo metadata (EXIF / GPS).</p><span class="pf-go">exif.mrzk.io →</span></a>
+  <a class="pf-card" href="https://favicon.mrzk.io"><h3>Favicon Generator</h3><p>Turn any image into a full favicon set + zip.</p><span class="pf-go">favicon.mrzk.io →</span></a>
+</div>


### PR DESCRIPTION
Restyle /portfolio as a card grid (Apps/Libraries/Tools, brand-accent cards); layout=simple drops the TOC + the empty section article-list. Validated on Hugo 0.163.3.