### PR TITLE
feat: portfolio thumbnails + dark-mode fix

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -53,7 +53,7 @@ code::after {
     content: "" !important;
 }
 
-/* ── Portfolio cards ─────────────────────────────────────────── */
+/* ── Portfolio cards (image-led, light + dark) ───────────────── */
 .pf-h {
     font-size: 1.5rem;
     font-weight: 700;
@@ -67,16 +67,14 @@ code::after {
 }
 .pf-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.1rem;
     margin: 0 0 1.5rem;
 }
 .pf-card {
     display: flex;
     flex-direction: column;
-    position: relative;
     overflow: hidden;
-    padding: 1.3rem 1.4rem 1.25rem;
     border: 1px solid rgb(var(--color-neutral-200));
     border-radius: 14px;
     background: rgb(var(--color-neutral));
@@ -84,29 +82,30 @@ code::after {
     color: inherit;
     transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease;
 }
-.pf-card::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4px;
-    background: linear-gradient(90deg, #2f9d8d 0 33.3%, #e8b04b 33.3% 66.6%, #d9594c 66.6%);
-}
 .pf-card:hover {
     transform: translateY(-3px);
-    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.10);
     border-color: rgb(var(--color-neutral-300));
 }
+.pf-thumb {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1200 / 630;
+    object-fit: cover;
+    border-bottom: 1px solid rgb(var(--color-neutral-200));
+}
+.pf-body {
+    padding: 0.95rem 1.15rem 1.1rem;
+}
 .pf-card h3 {
-    margin: 0.45rem 0 0.4rem;
-    font-size: 1.08rem;
+    margin: 0 0 0.35rem;
+    font-size: 1.05rem;
     font-weight: 700;
     color: rgb(var(--color-neutral-900));
 }
 .pf-card p {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.87rem;
     line-height: 1.5;
     color: rgb(var(--color-neutral-600));
 }
@@ -119,20 +118,22 @@ code::after {
     padding: 0.05rem 0.32rem;
     border-radius: 4px;
 }
-.pf-go {
-    margin-top: 0.75rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: #2f9d8d;
-    font-family: monospace;
-}
 .pf-links {
-    margin-top: 0.75rem;
+    display: inline-block;
+    margin-top: 0.6rem;
     font-size: 0.85rem;
 }
 .pf-links a {
     color: #2f9d8d;
     font-weight: 600;
+}
+
+/* dark mode — flip card surface AND text (the bug was dark text on dark cards) */
+.dark .pf-h {
+    color: rgb(var(--color-neutral-100));
+}
+.dark .pf-note {
+    color: rgb(var(--color-neutral-400));
 }
 .dark .pf-card {
     background: rgb(var(--color-neutral-800));
@@ -141,8 +142,21 @@ code::after {
 .dark .pf-card:hover {
     border-color: rgb(var(--color-neutral-600));
 }
-.dark .pf-go,
+.dark .pf-thumb {
+    border-bottom-color: rgb(var(--color-neutral-700));
+}
+.dark .pf-card h3 {
+    color: rgb(var(--color-neutral-100));
+}
+.dark .pf-card p {
+    color: rgb(var(--color-neutral-400));
+}
+.dark .pf-card p em {
+    color: rgb(var(--color-neutral-500));
+}
+.dark .pf-card code {
+    background: rgb(var(--color-neutral-900));
+}
 .dark .pf-links a {
     color: #41b6a6;
 }
-

--- a/content/portfolio/_index.md
+++ b/content/portfolio/_index.md
@@ -11,30 +11,28 @@ Everything I've built — an app, a library, and a growing set of free, **privat
 <h2 class="pf-h">Apps</h2>
 <div class="pf-grid">
   <a class="pf-card" href="https://colours.mrzk.io">
-    <h3>colours</h3>
-    <p>A colour gradient &amp; palette toolkit — stepped LAB gradients, seedable harmonious palettes, WCAG contrast + colour-blindness checks, and export to CSS / Tailwind / SCSS / JSON / SVG.</p>
-    <span class="pf-go">colours.mrzk.io →</span>
+    <img class="pf-thumb" src="https://colours.mrzk.io/og.png" alt="colours" loading="lazy">
+    <div class="pf-body"><h3>colours</h3><p>Colour gradient &amp; palette toolkit — LAB gradients, harmonious palettes, contrast + colour-blindness checks, export to CSS/Tailwind/SVG.</p></div>
   </a>
 </div>
 
 <h2 class="pf-h">Libraries</h2>
 <div class="pf-grid">
   <div class="pf-card">
-    <h3>charted</h3>
-    <p>Zero-dependency SVG charting for Python — <code>pip install charted</code>. 15 chart types, no numpy/pandas/matplotlib. Pure stdlib, runs anywhere, ships an MCP server.</p>
-    <span class="pf-links"><a href="https://charted.mrzk.io">site</a> · <a href="https://pypi.org/project/charted/">PyPI</a> · <a href="https://github.com/marzukia/charted">GitHub</a></span>
+    <a href="https://charted.mrzk.io"><img class="pf-thumb" src="https://charted.mrzk.io/_static/og-image.png" alt="charted" loading="lazy"></a>
+    <div class="pf-body"><h3>charted</h3><p>Zero-dependency SVG charting for Python — <code>pip install charted</code>. 15 chart types, no numpy/pandas/matplotlib, ships an MCP server.</p><span class="pf-links"><a href="https://charted.mrzk.io">site</a> · <a href="https://pypi.org/project/charted/">PyPI</a> · <a href="https://github.com/marzukia/charted">GitHub</a></span></div>
   </div>
 </div>
 
 <h2 class="pf-h">Tools</h2>
 <p class="pf-note">Free, and everything happens in your browser — nothing is ever uploaded.</p>
 <div class="pf-grid">
-  <a class="pf-card" href="https://pdf.mrzk.io"><h3>PDF Toolkit</h3><p>Merge, split, compress &amp; convert PDFs <em>(an iLovePDF / Smallpdf alternative)</em>.</p><span class="pf-go">pdf.mrzk.io →</span></a>
-  <a class="pf-card" href="https://convert.mrzk.io"><h3>Image Converter</h3><p>HEIC→JPG, WebP, PNG — compress &amp; resize <em>(a TinyPNG alternative)</em>.</p><span class="pf-go">convert.mrzk.io →</span></a>
-  <a class="pf-card" href="https://qr.mrzk.io"><h3>QR Code Generator</h3><p>QR codes with logo, colours &amp; dot styles. PNG / SVG export.</p><span class="pf-go">qr.mrzk.io →</span></a>
-  <a class="pf-card" href="https://ocr.mrzk.io"><h3>Image to Text (OCR)</h3><p>Extract text from any image, right in your browser.</p><span class="pf-go">ocr.mrzk.io →</span></a>
-  <a class="pf-card" href="https://og.mrzk.io"><h3>OG Image Generator</h3><p>Make social share images (1200×630) in seconds.</p><span class="pf-go">og.mrzk.io →</span></a>
-  <a class="pf-card" href="https://subs.mrzk.io"><h3>Subtitle Editor</h3><p>Edit, time-shift &amp; convert .srt / .vtt subtitles.</p><span class="pf-go">subs.mrzk.io →</span></a>
-  <a class="pf-card" href="https://exif.mrzk.io"><h3>EXIF Viewer &amp; Stripper</h3><p>View and remove photo metadata (EXIF / GPS).</p><span class="pf-go">exif.mrzk.io →</span></a>
-  <a class="pf-card" href="https://favicon.mrzk.io"><h3>Favicon Generator</h3><p>Turn any image into a full favicon set + zip.</p><span class="pf-go">favicon.mrzk.io →</span></a>
+  <a class="pf-card" href="https://pdf.mrzk.io"><img class="pf-thumb" src="https://pdf.mrzk.io/og.png" alt="PDF Toolkit" loading="lazy"><div class="pf-body"><h3>PDF Toolkit</h3><p>Merge, split, compress &amp; convert PDFs <em>(iLovePDF / Smallpdf alternative)</em>.</p></div></a>
+  <a class="pf-card" href="https://convert.mrzk.io"><img class="pf-thumb" src="https://convert.mrzk.io/og.png" alt="Image Converter" loading="lazy"><div class="pf-body"><h3>Image Converter</h3><p>HEIC→JPG, WebP, PNG — compress &amp; resize <em>(TinyPNG alternative)</em>.</p></div></a>
+  <a class="pf-card" href="https://qr.mrzk.io"><img class="pf-thumb" src="https://qr.mrzk.io/og.png" alt="QR Code Generator" loading="lazy"><div class="pf-body"><h3>QR Code Generator</h3><p>QR codes with logo, colours &amp; dot styles. PNG / SVG.</p></div></a>
+  <a class="pf-card" href="https://ocr.mrzk.io"><img class="pf-thumb" src="https://ocr.mrzk.io/og.png" alt="Image to Text OCR" loading="lazy"><div class="pf-body"><h3>Image to Text (OCR)</h3><p>Extract text from any image, in your browser.</p></div></a>
+  <a class="pf-card" href="https://og.mrzk.io"><img class="pf-thumb" src="https://og.mrzk.io/og.png" alt="OG Image Generator" loading="lazy"><div class="pf-body"><h3>OG Image Generator</h3><p>Make social share images (1200×630) in seconds.</p></div></a>
+  <a class="pf-card" href="https://subs.mrzk.io"><img class="pf-thumb" src="https://subs.mrzk.io/og.png" alt="Subtitle Editor" loading="lazy"><div class="pf-body"><h3>Subtitle Editor</h3><p>Edit, time-shift &amp; convert .srt / .vtt.</p></div></a>
+  <a class="pf-card" href="https://exif.mrzk.io"><img class="pf-thumb" src="https://exif.mrzk.io/og.png" alt="EXIF Viewer and Stripper" loading="lazy"><div class="pf-body"><h3>EXIF Viewer &amp; Stripper</h3><p>View and remove photo metadata (EXIF / GPS).</p></div></a>
+  <a class="pf-card" href="https://favicon.mrzk.io"><img class="pf-thumb" src="https://favicon.mrzk.io/og.png" alt="Favicon Generator" loading="lazy"><div class="pf-body"><h3>Favicon Generator</h3><p>Turn any image into a full favicon set + zip.</p></div></a>
 </div>


### PR DESCRIPTION
Image-led cards using each tool's live og.png as the thumbnail; fixed dark mode (text was near-black on dark cards). Validated light+dark on Hugo 0.163.3.